### PR TITLE
Fixed error when placing payment and others

### DIFF
--- a/app/code/community/Fontis/CommWeb/etc/config.xml
+++ b/app/code/community/Fontis/CommWeb/etc/config.xml
@@ -62,6 +62,16 @@
                 </connection>
             </commWeb_read>
         </resources>
+        <fieldsets>
+            <sales_convert_quote_payment>
+                <cc_number_for_payment>
+                    <to_order_payment>*</to_order_payment>
+                </cc_number_for_payment>
+                <cc_cid_for_payment>
+                    <to_order_payment>*</to_order_payment>
+                </cc_cid_for_payment>
+    		</sales_convert_quote_payment>
+		</fieldsets>                
     </global>
 	<default>
         <payment>


### PR DESCRIPTION
Fixed errors:
- disappearing CC number and CSC number before placing the payment;
- Warning: var_export does not handle circular references;
- replaced custom logger with Abstract::_debug()
